### PR TITLE
Node update

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,21 +31,6 @@ execute "install cube" do
   creates "/node_modules/cube"
 end
 
-execute "initialize cube database" do
-  command "mongo cube_development /node_modules/cube/schema/schema-create.js"
-  creates "/var/lib/mongodb/cube_development.ns"
-end
-
-template "/usr/src/schema-update.js" do
-  source "schema-update.js.erb"
-  notifies :run, "execute[update cube database schema]"
-end
-
-execute "update cube database schema" do
-  command "mongo cube_development /usr/src/schema-update.js"
-  action :nothing
-end
-
 template "/etc/init/collector.conf" do
   mode "644"
   notifies :restart, "service[collector]"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,9 +24,6 @@ include_recipe "mongodb"
 
 user "node"
 
-node.set[:nodejs][:version] = "0.4.8"
-node.set[:nodejs][:npm] = "1.0.106"
-
 include_recipe "nodejs::npm"
 
 execute "install cube" do


### PR DESCRIPTION
I don't see any mention on cube's site about the 0.4 dependency. The nodejs cookbook also doesn't compile 0.4.8 on Ubuntu 12.04 correctly.

Bumped to the latest version and everything seems to be working, but I'm new to Cube so not sure how to test that it's really working.
